### PR TITLE
Cambio en el título y en la descripción

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site settings
-title: Algoritmos y Programación II
+title: Teoría de Algoritmos I
 description: >
-  Página de la materia Algoritmos y Programación II, curso Buchwald.
+  Página de la materia Teoría de Algoritmos I, curso Buchwald - Genender.
   Facultad de Ingeniería, Universidad de Buenos Aires.
 
 baseurl: "/tda_bg"
@@ -27,8 +27,7 @@ collections:
     permalink: /:path/
 
 defaults:
-  -
-    scope:
+  - scope:
       path: ""
       type: "tps"
     values:


### PR DESCRIPTION
En la vista de celular salía el titulo de la página de ALG II, lo actualize al de TDA al igual que la descripción.