### PR TITLE
Actualizar fechas de parcial para el 2C2023

### DIFF
--- a/_data/parciales.yml
+++ b/_data/parciales.yml
@@ -1,11 +1,11 @@
 parcial:
   label: Parcial
-  fecha: 2023-04-21
+  fecha: 2023-11-10
 
 recu1:
   label: Primer Recuperatorio
-  fecha: 2023-05-22
+  fecha: 2023-12-01
 
 recu2:
   label: Segundo Recuperatorio
-  fecha: 2023-06-16
+  fecha: 2023-12-15


### PR DESCRIPTION
Me di cuenta que las fechas de [esta página](https://algoritmos-rw.github.io/tda_bg/calendario/) quedaron mal. Calculo que de algún copypaste de Algo2