### PR TITLE
Cambio de latín Alumnus Teorius Algoritmus -> Discipulus Theoriae Algoritmi

### DIFF
--- a/material/guias/reducciones.md
+++ b/material/guias/reducciones.md
@@ -108,8 +108,8 @@ math: true
     las noches. El problema es que cuesta mucho dinero entrenar a dichos guardianes, por lo que quiere reducir al mínimo 
     la cantidad que sean necesarios entrenar. Sabe que cada guardian puede estar vigilando desde una esquina, y desde allí 
     tener visibilidad hasta cualquier otra esquina directa. Necesita determinar la cantidad mínima de guardianes que son 
-    necesarios para cubrir todas las calles de su reino. Como primera medida, consulta con el oráculo Alumnus Teorius 
-    Algoritmus (es decir, quien lee esta consigna), para determinar si esto es conseguible en corto tiempo (el oráculo le 
+    necesarios para cubrir todas las calles de su reino. Como primera medida, consulta con el oráculo Discipulus Theoriae
+    Algoritmi (es decir, quien lee esta consigna), para determinar si esto es conseguible en corto tiempo (el oráculo le
     pregunó algo sobre tiempo polinomial, que Aragorn no entendió y le dijo “si, eso”). 
     Tenemos que explicarle a Aragorn que este pedido no es realizable (y debe armarse de paciencia, o no buscar el mínimo 
     exacto), porque el problema de Guardianes de Gondor es, en realidad, un problema NP-Completo (en su versión de 


### PR DESCRIPTION
# Frase

Discipulus theoriae algoritmi

# Palabras
- Paradójicamente, la palabra que mas difícil fue de traducir fue "alumno". Mi primera intención fue ir por `alumnus`, sin embargo, `alumnus` no tiene la connotación que "alumno" tiene hoy en día; sino tiene la connotación de "pupilo". Así que después estaba entre: `scholaris`, `discipulus`, `studiosus`.
  - El termino `scholaris` (3ra declinación masculino) hace referencia a una persona que esta estudiando en una institución. No me gusto que suena medio rebuscado en español y tal vez se pierde el chiste.
  - Por lo que encontré, el termino `studiosus` (adjetivos de 1ra/2da), tiene el significado de "ansioso" mas frecuentemente que el de "estudioso". Lo que tiene de lindo `studiosus` es que puede venir acompañado del campo de estudio de la persona para hacer referencia a "un estudioso de una materia en particular".  
  - El termino `discipulus` (2da declinacion ) , era uno con mucha frecuencia y era el que tenia el significado mas parecido al de "alumno" como entendemos hoy en día. Ademas, la palabra "discipulo" existe en español y casi un sinónimo. Como dato adicional, encontré un libro [12] que tiene el mismo uso que `studiosus` para indicar el sujeto de estudio de alguien; no es mucho pero al menos da lugar a pensar que es un uso valido.
- `theoria` "Teoria" fue dentro de todo es una palabra estándar para hablar de "teoría" (ejemplo: `theoria copiarum`: "Teoria de conjuntos").
- "Algoritmo" fue súper interesante. Martín en una clase menciono (Si mal no recuerdo) que era la latinizacion de un matemático árabe. Por lo que encontré, viene de un libro de Muḥammad ibn Mūsā al-Khwārizmī (محمد بن موسى خوارزمی) que fue traducido al latín como "Algoritmi de numero Indorum". En teoría, tanto `algorismi` como `algoritmi` son validos. Pero como el libro se tradujo como `algoritmi` y es la palabra mas parecida al español, fui por esa. Cabe destacar que el concepto de "algoritmo" llega en un periodo de latín tardío. La palabra "mechanisma", es un "equivalente" del latín antiguo. Pero me parecía que hubiese sido mas difícil de entender el chiste con una traducción tan "exacta". En wiktionary figura solamente `algorismus` (`algoritmus` no figura como palabra latina), sin embargo, la traducción del libro de Khwarizmi (por lo que encontre) es "algoritmi" (entiendo que, al igual que `algorismus` también es de la segunda declinación masculino y que `algoritmi` es el nominativo plural). 
  
# Declinaciones

`discipulus` esta  en nominativo masculino singular porque es nombre del oráculo.
Después, `theoria` y `algoritmus` estan en genitivo porque estan modificando a `discipulus` (indicando el sujeto de estudio). 

# Fuentes:
[1] https://latin.stackexchange.com/questions/6432/how-would-one-talk-about-an-algorithm

[2] https://en.wiktionary.org/wiki/scholaris

[3] https://en.wiktionary.org/wiki/algorismus

[4] https://en.wiktionary.org/wiki/theoria#Latin 

[5] https://latin.stackexchange.com/questions/23649/how-to-say-math-student-or-other-subjects 

[6] https://en.wikipedia.org/wiki/Alumni

[7] http://www.perseus.tufts.edu/hopper/morph?l=alumnus&la=la&can=alumnus0#lexicon

[8] https://en.wiktionary.org/wiki/studiosus

[10] http://www.perseus.tufts.edu/hopper/morph?l=discipulus&la=la&can=discipulus0#lexicon

[11] https://en.wiktionary.org/wiki/discipulus

[12] https://books.google.com.ar/books?id=sKpLAAAAcAAJ&printsec=frontcover&redir_esc=y#v=onepage&q&f=false

[13] Dizionario Latino DeAgostini - 2009
