### PR TITLE
Fix: Corregir renderizado de LaTeX en el problema 2-Partition

### DIFF
--- a/material/guias/pl.md
+++ b/material/guias/pl.md
@@ -74,13 +74,13 @@ math: true
 	político. Indicar la cantidad de inecuaciones definidas en el modelo.
 
 1.	(★★) El _2-Partition Problem_ como problema de optimización se describe tal que: 
-	Dado un conjunto de $n$ números positivos $T= \lbrace T_1, T_2, \dots, T_n \rbrace$, 
-	se particionan los números en dos subconjuntos $S_1$ y $S_2$ (con intersección vacía y 
+	Dado un conjunto de $$n$$ números positivos $$T= \lbrace T_1, T_2, \dots, T_n \rbrace$$, 
+	se particionan los números en dos subconjuntos $$S_1$$ y $$S_2$$ (con intersección vacía y 
 	unión = T) de forma de minimizar la sumatoria de cualquiera de los subconjuntos 
-	($\min \max (S_1, S_2)$).
+	($$\min \max (S_1, S_2)$$).
 
-	Implementar un modelo de **programación lineal** que dados los valores de los $T_i$ 
-	nos permita obtener la asignación óptima para $S_1$ y $S_2$. Indicar la cantidad de
+	Implementar un modelo de **programación lineal** que dados los valores de los $$T_i$$ 
+	nos permita obtener la asignación óptima para $$S_1$$ y $$S_2$$. Indicar la cantidad de
 	inecuaciones definidas en el modelo.
 
 {::options toc_levels="2" /}


### PR DESCRIPTION
Actualmente, para el 2-Partition Problem, las expresiones en LaTeX se renderizan de forma incorrecta:

<img width="727" height="204" alt="image" src="https://github.com/user-attachments/assets/1d578b8a-02d7-47cc-9c68-b513d405dbe0" />

Deberían renderizarse así:

<img width="727" height="204" alt="image" src="https://github.com/user-attachments/assets/cbb4fb26-3410-41ae-bbaa-980feeb79715" />
